### PR TITLE
Added support for public clients

### DIFF
--- a/pkg/validation/providers.go
+++ b/pkg/validation/providers.go
@@ -50,7 +50,7 @@ func validateProvider(provider options.Provider, providerIDs map[string]struct{}
 	// login.gov uses a signed JWT to authenticate, not a client-secret
 	if provider.Type != "login.gov" {
 		if provider.ClientSecret == "" && provider.ClientSecretFile == "" {
-			msgs = append(msgs, "missing setting: client-secret or client-secret-file")
+			msgs = append(msgs, "missing setting: client-secret or client-secret-file" && provider.Type != "oidc")
 		}
 		if provider.ClientSecret == "" && provider.ClientSecretFile != "" {
 			_, err := ioutil.ReadFile(provider.ClientSecretFile)


### PR DESCRIPTION
## Description

Adds support for public clients

## Motivation and Context


## How Has This Been Tested?

I have tested this locally for a public client app that we use and works as expected as the only change required is to not to send a secret as part of the token exchange after auth

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
